### PR TITLE
OSX tweaks on top of your existing PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.project
 *~
 aclocal.m4
 autom4te.cache/

--- a/src/zooadd.c
+++ b/src/zooadd.c
@@ -8,8 +8,9 @@
 #include "options.h"
 
 #ifdef HAVE_NFTW
-#define _XOPEN_SOURCE 500	/* Rrequired on GLIBC */
-#define _GNU_SOURCE		/* -- " -- " -- " --  */
+#define _XOPEN_SOURCE 500	/* Required on GLIBC */
+#define _GNU_SOURCE		/* -- " -- " -- " -- */
+#define _POSIX_C_SOURCE 200809L	/* -- " -- " -- " -- */
 #include <ftw.h>
 #endif
 


### PR DESCRIPTION
Defining `_POSIX_C_SOURCE` to a value equal or greater than 200809L allows us to re-acquire non-standard library functions (`strdup()` in our case is a posix extension) that strict ANSI checking hides.